### PR TITLE
fix: add epub medata title

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -86,8 +86,8 @@ def to_epub(root_dir, force=False):
     title, author, cover_image, css = get_meta(root_dir)
 
     doc = pandoc.write(pandoc.read(content, format='commonmark'), format='epub',
-                       options=[f'--title={title}', f'--css={css}', f'--epub-cover-image={cover_image}',
-                                '--metadata', f'author={author}'])
+                       options=[f'--css={css}', f'--epub-cover-image={cover_image}',
+                                '--metadata', f'author={author}', '--metadata', f'title={title}'])
     print(f'{root_dir} to epub finish')
     write_bytes(os.path.join(root_dir, f'{course_name}.epub'), doc)
 


### PR DESCRIPTION
## Problem:
- The 2nd page of epub eBook doesn't show the book title.
- Moon+ Reader(an Android App) can't recognize the book title
<img src="https://user-images.githubusercontent.com/11900676/167247549-8065a4da-9e1e-4d5f-add0-0161f9c2698d.jpg" height="500"/>

## After add metadata title :
<img src="https://user-images.githubusercontent.com/11900676/167247850-07e85fa6-744d-4f51-996f-01b9ffa894a5.jpg" height="500"/>
